### PR TITLE
Remove usersRole query param from pagination links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-# 18/11/2019
+# 09/12/2019
+- Fix issue where pagination links in GET layers would have unexpected `usersRole` parameter.
 
+# 18/11/2019
 - Add support for dataset overwrite using multiple files in parallel.
 - Update node version to 12.
 - Replace npm with yarn.

--- a/app/src/routes/api/v1/layer.router.js
+++ b/app/src/routes/api/v1/layer.router.js
@@ -179,6 +179,7 @@ class LayerRouter {
         delete clonedQuery['page[size]'];
         delete clonedQuery['page[number]'];
         delete clonedQuery.ids;
+        delete clonedQuery.usersRole;
         const serializedQuery = serializeObjToQuery(clonedQuery) ? `?${serializeObjToQuery(clonedQuery)}&` : '?';
         const apiVersion = ctx.mountPath.split('/')[ctx.mountPath.split('/').length - 1];
         const link = `${ctx.request.protocol}://${ctx.request.host}/${apiVersion}${ctx.request.path}${serializedQuery}`;

--- a/app/test/e2e/layer-get.spec.js
+++ b/app/test/e2e/layer-get.spec.js
@@ -277,6 +277,10 @@ describe('Get layers', () => {
 
         list.body.should.have.property('links').and.be.an('object');
         list.body.links.should.have.property('self').and.not.includes('usersRole=');
+        list.body.links.should.have.property('next').and.not.includes('usersRole=');
+        list.body.links.should.have.property('prev').and.not.includes('usersRole=');
+        list.body.links.should.have.property('first').and.not.includes('usersRole=');
+        list.body.links.should.have.property('last').and.not.includes('usersRole=');
     });
 
     afterEach(async () => {

--- a/app/test/e2e/layer-get.spec.js
+++ b/app/test/e2e/layer-get.spec.js
@@ -267,6 +267,18 @@ describe('Get layers', () => {
         });
     });
 
+    it('Getting layers filtered by user.role should not return a query param "usersRole" in the pagination links', async () => {
+        await new Layer(createLayer()).save();
+        createMockUserRole('ADMIN', ADMIN.id);
+
+        const list = await requester
+            .get('/api/v1/layer?user.role=ADMIN')
+            .query({ loggedUser: JSON.stringify(ADMIN) });
+
+        list.body.should.have.property('links').and.be.an('object');
+        list.body.links.should.have.property('self').and.not.includes('usersRole=');
+    });
+
     afterEach(async () => {
         await Layer.deleteMany({}).exec();
 


### PR DESCRIPTION
This PR relates to the following PT task: https://www.pivotaltracker.com/story/show/169483688

When providing the query param filter `user.role`, a query parameter `usersRole` was added to the generated pagination links, not only being unnecessary but also increasing the size of the pagination link in some weird cases (check the related PT task).

This PR removes the `usersRole` parameter from the query params of the pagination links, thus returning correctly formatted links once again.