### PR TITLE
Sort layers by user role or name

### DIFF
--- a/app/Gruntfile.js
+++ b/app/Gruntfile.js
@@ -23,6 +23,7 @@ module.exports = (grunt) => {
                 options: {
                     reporter: 'spec',
                     quiet: false,
+                    timeout: 10000,
                     clearRequireCache: true,
                 },
                 src: ['app/test/e2e/**/*.spec.js']

--- a/app/src/models/layer.model.js
+++ b/app/src/models/layer.model.js
@@ -32,6 +32,8 @@ const Layer = new Schema({
     applicationConfig: { type: Schema.Types.Mixed },
     interactionConfig: { type: Schema.Types.Mixed },
     staticImageConfig: { type: Schema.Types.Mixed },
+    userRole: { type: String, default: null, select: false },
+    userName: { type: String, default: null, select: false },
     createdAt: { type: Date, default: Date.now },
     updatedAt: { type: Date, default: Date.now }
 });

--- a/app/src/routes/api/v1/layer.router.js
+++ b/app/src/routes/api/v1/layer.router.js
@@ -165,6 +165,10 @@ class LayerRouter {
             )));
         }
 
+        if (query['page[size]'] && query['page[size]'] > 100) {
+            ctx.throw(400, 'Invalid page size');
+        }
+
         if (Object.keys(query).find((el) => el.indexOf('collection') >= 0)) {
             if (!userId) {
                 ctx.throw(403, 'Collection filter not authorized');

--- a/app/src/routes/api/v1/layer.router.js
+++ b/app/src/routes/api/v1/layer.router.js
@@ -161,7 +161,10 @@ class LayerRouter {
             const users = await RelationshipsService.getUsersInfoByIds(ids);
             await Promise.all(users.map((u) => LayerModel.updateMany(
                 { userId: u._id },
-                { userRole: u.role.toLowerCase(), userName: u.name.toLowerCase() },
+                {
+                    userRole: u.role ? u.role.toLowerCase() : '',
+                    userName: u.name ? u.name.toLowerCase() : ''
+                },
             )));
         }
 

--- a/app/src/routes/api/v1/layer.router.js
+++ b/app/src/routes/api/v1/layer.router.js
@@ -159,7 +159,6 @@ class LayerRouter {
             }
             const ids = await LayerService.getAllLayersUserIds();
             const users = await RelationshipsService.getUsersInfoByIds(ids);
-
             await Promise.all(users.map((u) => LayerModel.updateMany(
                 { userId: u._id },
                 { userRole: u.role, userName: u.name },

--- a/app/src/routes/api/v1/layer.router.js
+++ b/app/src/routes/api/v1/layer.router.js
@@ -161,7 +161,7 @@ class LayerRouter {
             const users = await RelationshipsService.getUsersInfoByIds(ids);
             await Promise.all(users.map((u) => LayerModel.updateMany(
                 { userId: u._id },
-                { userRole: u.role, userName: u.name },
+                { userRole: u.role.toLowerCase(), userName: u.name.toLowerCase() },
             )));
         }
 

--- a/app/src/routes/api/v1/layer.router.js
+++ b/app/src/routes/api/v1/layer.router.js
@@ -149,6 +149,13 @@ class LayerRouter {
         const isAdmin = ['ADMIN', 'SUPERADMIN'].includes(user && user.role);
 
         delete query.loggedUser;
+        if (ctx.query.sort === 'user.role' || ctx.query.sort === 'user.name') {
+            logger.debug('Detected sorting by user role or name');
+            if (!user || !isAdmin) {
+                ctx.throw(403, 'Sorting by user name or role not authorized.');
+                return;
+            }
+        }
         if (Object.keys(query).find((el) => el.indexOf('collection') >= 0)) {
             if (!userId) {
                 ctx.throw(403, 'Collection filter not authorized');

--- a/app/src/services/layer.service.js
+++ b/app/src/services/layer.service.js
@@ -107,8 +107,7 @@ class LayerService {
     }
 
     static getFilteredSort(sort) {
-        const processedStr = LayerService.processSortParam(sort);
-        const sortParams = processedStr.split(',');
+        const sortParams = LayerService.processSortParam(sort).split(',');
         const filteredSort = {};
         const layerAttributes = Object.keys(Layer.schema.obj);
         sortParams.forEach((param) => {

--- a/app/src/services/layer.service.js
+++ b/app/src/services/layer.service.js
@@ -99,8 +99,16 @@ class LayerService {
         return query;
     }
 
+    static processSortParam(sort) {
+        let processedStr = sort;
+        if (sort.includes('user.role')) processedStr = processedStr.replace(/user.role/g, 'userRole');
+        if (sort.includes('user.name')) processedStr = processedStr.replace(/user.name/g, 'userName');
+        return processedStr;
+    }
+
     static getFilteredSort(sort) {
-        const sortParams = sort.split(',');
+        const processedStr = LayerService.processSortParam(sort);
+        const sortParams = processedStr.split(',');
         const filteredSort = {};
         const layerAttributes = Object.keys(Layer.schema.obj);
         sortParams.forEach((param) => {
@@ -364,6 +372,13 @@ class LayerService {
         }
         logger.debug(`[LayerService] IDs query: ${JSON.stringify(query)}`);
         return Layer.find(query).exec();
+    }
+
+    static async getAllLayersUserIds() {
+        logger.debug(`[LayerService]: Getting the user ids of all layers`);
+        const layers = await Layer.find({}, 'userId').lean();
+        const userIds = layers.map((l) => l.userId);
+        return userIds.filter((item, idx) => userIds.indexOf(item) === idx && item !== 'legacy');
     }
 
     static async hasPermission(id, user) {

--- a/app/src/services/layer.service.js
+++ b/app/src/services/layer.service.js
@@ -100,10 +100,7 @@ class LayerService {
     }
 
     static processSortParam(sort) {
-        let processedStr = sort;
-        if (sort.includes('user.role')) processedStr = processedStr.replace(/user.role/g, 'userRole,_id');
-        if (sort.includes('user.name')) processedStr = processedStr.replace(/user.name/g, 'userName,_id');
-        return processedStr;
+        return sort.replace(/user.role/g, 'userRole,_id').replace(/user.name/g, 'userName,_id');
     }
 
     static getFilteredSort(sort) {

--- a/app/src/services/layer.service.js
+++ b/app/src/services/layer.service.js
@@ -101,8 +101,8 @@ class LayerService {
 
     static processSortParam(sort) {
         let processedStr = sort;
-        if (sort.includes('user.role')) processedStr = processedStr.replace(/user.role/g, 'userRole');
-        if (sort.includes('user.name')) processedStr = processedStr.replace(/user.name/g, 'userName');
+        if (sort.includes('user.role')) processedStr = processedStr.replace(/user.role/g, 'userRole,_id');
+        if (sort.includes('user.name')) processedStr = processedStr.replace(/user.name/g, 'userName,_id');
         return processedStr;
     }
 

--- a/app/src/services/relationships.service.js
+++ b/app/src/services/relationships.service.js
@@ -30,17 +30,13 @@ class RelationshipsService {
                         version: false
                     });
 
-                    if (!userData.data[0] || (!userData.data[0].name && !userData.data[0].email)) {
+                    if (!userData.data[0]) {
                         logger.warn(`Tried to use find-by-ids to load info for user with id ${layers[i].userId} but the following was returned: ${JSON.stringify(user)}`);
                     } else {
-                        layers[i].user = {
-                            name: userData.data[0].name,
-                            email: userData.data[0].email
-                        };
-                        if (user && user.role === 'ADMIN') {
-                            layers[i].user.role = userData.data[0].role;
-                        }
-
+                        layers[i].user = {};
+                        if (userData.data[0].name) layers[i].user.name = userData.data[0].name;
+                        if (userData.data[0].email) layers[i].user.email = userData.data[0].email;
+                        if (user && user.role === 'ADMIN') layers[i].user.role = userData.data[0].role;
                         logger.info('Layers including user data', layers.map((el) => el.toObject()));
                     }
                 }

--- a/app/src/services/relationships.service.js
+++ b/app/src/services/relationships.service.js
@@ -51,6 +51,19 @@ class RelationshipsService {
         return layers;
     }
 
+    static async getUsersInfoByIds(ids) {
+        logger.debug('Fetching all users\' information');
+        const body = await ctRegisterMicroservice.requestToMicroservice({
+            uri: `/auth/user/find-by-ids`,
+            method: 'POST',
+            json: true,
+            version: false,
+            body: { ids }
+        });
+
+        return body.data;
+    }
+
     static async getUsersWithRole(role) {
         const body = await ctRegisterMicroservice.requestToMicroservice({
             uri: `/auth/user/ids/${role}`,

--- a/app/test/e2e/layer-get-by-id.spec.js
+++ b/app/test/e2e/layer-get-by-id.spec.js
@@ -29,25 +29,27 @@ describe('Get layers by id', () => {
 
     it('Getting layers by id should return the layer when it exists (happy case)', async () => {
         const savedLayer = await new Layer(createLayer()).save();
+        const foundLayer = await Layer.findById(savedLayer._id);
 
-        const layer = await requester.get(`/api/v1/layer/${savedLayer._id}`);
+        const layer = await requester.get(`/api/v1/layer/${foundLayer._id}`);
         layer.status.should.equal(200);
-        ensureCorrectLayer(layer.body.data, savedLayer.toObject());
+        ensureCorrectLayer(layer.body.data, foundLayer.toObject());
     });
 
     it('Getting layers as anonymous user with includes=user should return a list of layers and no user data (happy case)', async () => {
         const savedLayer = await new Layer(createLayer(null, null, null, USER.id)).save();
+        const foundLayer = await Layer.findById(savedLayer._id);
 
         createMockUser([USER]);
 
-        const list = await requester.get(`/api/v1/layer/${savedLayer._id}`)
+        const list = await requester.get(`/api/v1/layer/${foundLayer._id}`)
             .query({
                 includes: 'user',
                 loggedUser: JSON.stringify(USER)
             });
 
         list.body.should.have.property('data');
-        ensureCorrectLayer(list.body.data, savedLayer.toObject(), {
+        ensureCorrectLayer(list.body.data, foundLayer.toObject(), {
             user: {
                 email: USER.email,
                 name: USER.name
@@ -57,17 +59,18 @@ describe('Get layers by id', () => {
 
     it('Getting layers with USER role and includes=user should return a list of layers and user name and email (happy case)', async () => {
         const savedLayer = await new Layer(createLayer(null, null, null, USER.id)).save();
+        const foundLayer = await Layer.findById(savedLayer._id);
 
         createMockUser([USER]);
 
-        const list = await requester.get(`/api/v1/layer/${savedLayer._id}`)
+        const list = await requester.get(`/api/v1/layer/${foundLayer._id}`)
             .query({
                 includes: 'user',
                 loggedUser: JSON.stringify(USER)
             });
 
         list.body.should.have.property('data');
-        ensureCorrectLayer(list.body.data, savedLayer.toObject(), {
+        ensureCorrectLayer(list.body.data, foundLayer.toObject(), {
             user: {
                 email: USER.email,
                 name: USER.name
@@ -77,17 +80,18 @@ describe('Get layers by id', () => {
 
     it('Getting layers with MANAGER role and includes=user should return a list of layers and user name and email (happy case)', async () => {
         const savedLayer = await new Layer(createLayer(null, null, null, USER.id)).save();
+        const foundLayer = await Layer.findById(savedLayer._id);
 
         createMockUser([USER]);
 
-        const list = await requester.get(`/api/v1/layer/${savedLayer._id}`)
+        const list = await requester.get(`/api/v1/layer/${foundLayer._id}`)
             .query({
                 includes: 'user',
                 loggedUser: JSON.stringify(MANAGER)
             });
 
         list.body.should.have.property('data');
-        ensureCorrectLayer(list.body.data, savedLayer.toObject(), {
+        ensureCorrectLayer(list.body.data, foundLayer.toObject(), {
             user: {
                 email: USER.email,
                 name: USER.name,
@@ -97,17 +101,18 @@ describe('Get layers by id', () => {
 
     it('Getting layers with ADMIN role and includes=user should return a list of layers and user name, email and role (happy case)', async () => {
         const savedLayer = await new Layer(createLayer(null, null, null, USER.id)).save();
+        const foundLayer = await Layer.findById(savedLayer._id);
 
         createMockUser([USER]);
 
-        const list = await requester.get(`/api/v1/layer/${savedLayer._id}`)
+        const list = await requester.get(`/api/v1/layer/${foundLayer._id}`)
             .query({
                 includes: 'user',
                 loggedUser: JSON.stringify(ADMIN)
             });
 
         list.body.should.have.property('data');
-        ensureCorrectLayer(list.body.data, savedLayer.toObject(), {
+        ensureCorrectLayer(list.body.data, foundLayer.toObject(), {
             user: {
                 email: USER.email,
                 name: USER.name,
@@ -125,11 +130,12 @@ describe('Get layers by id', () => {
     it('Getting layers by dataset should return the layers for specific dataset when dataset exists (happy case)', async () => {
         createMockDataset('123');
         const savedLayer = await new Layer(createLayer(['rw'], '123')).save();
+        const foundLayer = await Layer.findById(savedLayer._id);
 
         const datasetLayers = await requester.get(`/api/v1/dataset/123/layer`);
         datasetLayers.status.should.equal(200);
         datasetLayers.body.should.have.property('data').and.be.an('array').and.length.above(0);
-        ensureCorrectLayer(datasetLayers.body.data[0], savedLayer.toObject());
+        ensureCorrectLayer(datasetLayers.body.data[0], foundLayer.toObject());
     });
 
     afterEach(async () => {

--- a/app/test/e2e/layer-get-sort-user-fields.spec.js
+++ b/app/test/e2e/layer-get-sort-user-fields.spec.js
@@ -26,6 +26,33 @@ describe('GET layers sorted by user fields', () => {
         requester = await getTestServer();
     });
 
+    it('Getting layers sorted by user.role ASC without authentication should return 403 Forbidden', async () => {
+        await new Layer(createLayer()).save();
+
+        const response = await requester.get('/api/v1/layer').query({ sort: 'user.role' });
+        response.status.should.equal(403);
+        response.body.should.have.property('errors').and.be.an('array');
+        response.body.errors[0].should.have.property('detail').and.be.equal('Sorting by user name or role not authorized.');
+    });
+
+    it('Getting layers sorted by user.role ASC with user with role USER should return 403 Forbidden', async () => {
+        await new Layer(createLayer()).save();
+
+        const response = await requester.get('/api/v1/layer').query({ sort: 'user.role', loggedUser: JSON.stringify(USER) });
+        response.status.should.equal(403);
+        response.body.should.have.property('errors').and.be.an('array');
+        response.body.errors[0].should.have.property('detail').and.be.equal('Sorting by user name or role not authorized.');
+    });
+
+    it('Getting layers sorted by user.role ASC with user with role MANAGER should return 403 Forbidden', async () => {
+        await new Layer(createLayer()).save();
+
+        const response = await requester.get('/api/v1/layer').query({ sort: 'user.role', loggedUser: JSON.stringify(MANAGER) });
+        response.status.should.equal(403);
+        response.body.should.have.property('errors').and.be.an('array');
+        response.body.errors[0].should.have.property('detail').and.be.equal('Sorting by user name or role not authorized.');
+    });
+
     it('Getting layers sorted by user.role ASC should return a list of layers ordered by the role of the user who created the layer (happy case)', async () => {
         const layer1 = await new Layer(createLayer(null, null, null, USER.id)).save();
         const layer2 = await new Layer(createLayer(null, null, null, MANAGER.id)).save();

--- a/app/test/e2e/layer-get-sort-user-fields.spec.js
+++ b/app/test/e2e/layer-get-sort-user-fields.spec.js
@@ -1,0 +1,120 @@
+const nock = require('nock');
+const Layer = require('models/layer.model');
+const chai = require('chai');
+const { getTestServer } = require('./utils/test-server');
+const { createLayer } = require('./utils/helpers');
+const { createMockUser } = require('./utils/mocks');
+const {
+    USERS: {
+        USER, MANAGER, ADMIN, SUPERADMIN
+    }
+} = require('./utils/test.constants');
+
+chai.should();
+
+nock.disableNetConnect();
+nock.enableNetConnect(process.env.HOST_IP);
+
+let requester;
+
+describe('GET layers sorted by user fields', () => {
+    before(async () => {
+        if (process.env.NODE_ENV !== 'test') {
+            throw Error(`Running the test suite with NODE_ENV ${process.env.NODE_ENV} may result in permanent data loss. Please use NODE_ENV=test.`);
+        }
+
+        requester = await getTestServer();
+    });
+
+    it('Getting layers sorted by user.role ASC should return a list of layers ordered by the role of the user who created the layer (happy case)', async () => {
+        const layer1 = await new Layer(createLayer(null, null, null, USER.id)).save();
+        const layer2 = await new Layer(createLayer(null, null, null, MANAGER.id)).save();
+        const layer3 = await new Layer(createLayer(null, null, null, ADMIN.id)).save();
+        const layer4 = await new Layer(createLayer(null, null, null, SUPERADMIN.id)).save();
+
+        createMockUser([{ id: layer1.userId, role: 'USER', name: 'test user' }]);
+        createMockUser([{ id: layer2.userId, role: 'MANAGER', name: 'test user' }]);
+        createMockUser([{ id: layer3.userId, role: 'ADMIN', name: 'test user' }]);
+        createMockUser([{ id: layer4.userId, role: 'SUPERADMIN', name: 'test user' }]);
+
+        const response = await requester.get('/api/v1/layer').query({
+            includes: 'user',
+            sort: 'user.role',
+            loggedUser: JSON.stringify(ADMIN),
+        });
+        response.status.should.equal(200);
+        response.body.should.have.property('data').and.be.an('array').and.length(4);
+        response.body.data.map((layer) => layer.attributes.user.role).should.be.deep.equal(['ADMIN', 'MANAGER', 'SUPERADMIN', 'USER']);
+    });
+
+    it('Getting layers sorted by user.role DESC should return a list of layers ordered by the role of the user who created the layer (happy case)', async () => {
+        const layer1 = await new Layer(createLayer(null, null, null, USER.id)).save();
+        const layer2 = await new Layer(createLayer(null, null, null, MANAGER.id)).save();
+        const layer3 = await new Layer(createLayer(null, null, null, ADMIN.id)).save();
+        const layer4 = await new Layer(createLayer(null, null, null, SUPERADMIN.id)).save();
+
+        createMockUser([{ id: layer1.userId, role: 'USER', name: 'test user' }]);
+        createMockUser([{ id: layer2.userId, role: 'MANAGER', name: 'test user' }]);
+        createMockUser([{ id: layer3.userId, role: 'ADMIN', name: 'test user' }]);
+        createMockUser([{ id: layer4.userId, role: 'SUPERADMIN', name: 'test user' }]);
+
+        const response = await requester.get('/api/v1/layer').query({
+            includes: 'user',
+            sort: '-user.role',
+            loggedUser: JSON.stringify(ADMIN),
+        });
+        response.status.should.equal(200);
+        response.body.should.have.property('data').and.be.an('array').and.length(4);
+        response.body.data.map((layer) => layer.attributes.user.role).should.be.deep.equal(['USER', 'SUPERADMIN', 'MANAGER', 'ADMIN']);
+    });
+
+    it('Getting layers sorted by user.name ASC should return a list of layers ordered by the name of the user who created the layer (happy case)', async () => {
+        const layer1 = await new Layer(createLayer(null, null, null, USER.id)).save();
+        const layer2 = await new Layer(createLayer(null, null, null, MANAGER.id)).save();
+        const layer3 = await new Layer(createLayer(null, null, null, ADMIN.id)).save();
+        const layer4 = await new Layer(createLayer(null, null, null, SUPERADMIN.id)).save();
+
+        createMockUser([{ id: layer1.userId, role: 'USER', name: 'B' }]);
+        createMockUser([{ id: layer2.userId, role: 'MANAGER', name: 'A' }]);
+        createMockUser([{ id: layer3.userId, role: 'ADMIN', name: 'D' }]);
+        createMockUser([{ id: layer4.userId, role: 'SUPERADMIN', name: 'C' }]);
+
+        const response = await requester.get('/api/v1/layer').query({
+            includes: 'user',
+            sort: 'user.name',
+            loggedUser: JSON.stringify(ADMIN),
+        });
+        response.status.should.equal(200);
+        response.body.should.have.property('data').and.be.an('array').and.length(4);
+        response.body.data.map((layer) => layer.attributes.user.name).should.be.deep.equal(['A', 'B', 'C', 'D']);
+    });
+
+    it('Getting layers sorted by user.name DESC should return a list of layers ordered by the name of the user who created the layer (happy case)', async () => {
+        const layer1 = await new Layer(createLayer(null, null, null, USER.id)).save();
+        const layer2 = await new Layer(createLayer(null, null, null, MANAGER.id)).save();
+        const layer3 = await new Layer(createLayer(null, null, null, ADMIN.id)).save();
+        const layer4 = await new Layer(createLayer(null, null, null, SUPERADMIN.id)).save();
+
+        createMockUser([{ id: layer1.userId, role: 'USER', name: 'B' }]);
+        createMockUser([{ id: layer2.userId, role: 'MANAGER', name: 'A' }]);
+        createMockUser([{ id: layer3.userId, role: 'ADMIN', name: 'D' }]);
+        createMockUser([{ id: layer4.userId, role: 'SUPERADMIN', name: 'C' }]);
+
+        const response = await requester.get('/api/v1/layer').query({
+            includes: 'user',
+            sort: '-user.name',
+            loggedUser: JSON.stringify(ADMIN),
+        });
+        response.status.should.equal(200);
+        response.body.should.have.property('data').and.be.an('array').and.length(4);
+        response.body.data.map((layer) => layer.attributes.user.name).should.be.deep.equal(['A', 'B', 'C', 'D']);
+    });
+
+    afterEach(async () => {
+        await Layer.deleteMany({}).exec();
+
+        if (!nock.isDone()) {
+            throw new Error(`Not all nock interceptors were used: ${nock.pendingMocks()}`);
+        }
+    });
+});

--- a/app/test/e2e/layer-get.spec.js
+++ b/app/test/e2e/layer-get.spec.js
@@ -212,21 +212,21 @@ describe('Get layers', () => {
 
         createMockUser([{
             ...USER,
-            _id: foundLayerOne.userId,
+            id: foundLayerOne.userId,
             email: 'user-one@control-tower.org',
             name: 'test user',
             role: 'USER'
         }]);
         createMockUser([{
             ...MANAGER,
-            _id: foundLayerTwo.userId,
+            id: foundLayerTwo.userId,
             name: undefined,
             email: 'user-two@control-tower.org',
             role: 'MANAGER'
         }]);
         createMockUser([{
             ...ADMIN,
-            _id: foundLayerThree.userId,
+            id: foundLayerThree.userId,
             email: undefined,
             name: 'user three',
             role: 'MANAGER'

--- a/app/test/e2e/layer-get.spec.js
+++ b/app/test/e2e/layer-get.spec.js
@@ -211,45 +211,25 @@ describe('Get layers', () => {
         const foundLayerThree = await Layer.findById(savedLayerThree._id);
 
         createMockUser([{
-            id: foundLayerOne.userId,
-            role: 'USER',
-            provider: 'local',
+            ...USER,
+            _id: foundLayerOne.userId,
             email: 'user-one@control-tower.org',
             name: 'test user',
-            extraUserData: {
-                apps: [
-                    'rw',
-                    'gfw',
-                    'gfw-climate',
-                    'prep',
-                    'aqueduct',
-                    'forest-atlas'
-                ]
-            }
+            role: 'USER'
         }]);
-
         createMockUser([{
-            id: foundLayerTwo.userId,
-            role: 'MANAGER',
-            provider: 'local',
+            ...MANAGER,
+            _id: foundLayerTwo.userId,
+            name: undefined,
             email: 'user-two@control-tower.org',
-            extraUserData: {
-                apps: [
-                    'rw'
-                ]
-            }
+            role: 'MANAGER'
         }]);
-
         createMockUser([{
-            id: foundLayerThree.userId,
-            role: 'MANAGER',
-            provider: 'local',
+            ...ADMIN,
+            _id: foundLayerThree.userId,
+            email: undefined,
             name: 'user three',
-            extraUserData: {
-                apps: [
-                    'rw'
-                ]
-            }
+            role: 'MANAGER'
         }]);
 
         const list = await requester.get('/api/v1/layer')

--- a/app/test/e2e/layer-get.spec.js
+++ b/app/test/e2e/layer-get.spec.js
@@ -34,14 +34,16 @@ describe('Get layers', () => {
 
     it('Getting layers should return a list of layers (happy case)', async () => {
         const savedLayer = await new Layer(createLayer()).save();
+        const foundLayer = await Layer.findById(savedLayer._id);
 
         const list = await requester.get('/api/v1/layer');
         list.body.should.have.property('data').and.be.an('array').and.length.above(0);
-        ensureCorrectLayer(list.body.data[0], savedLayer.toObject());
+        ensureCorrectLayer(list.body.data[0], foundLayer.toObject());
     });
 
     it('Getting layers as ADMIN with query params user.role = ADMIN should return a list of layers created by ADMIN users (happy case)', async () => {
         const savedLayer = await new Layer(createLayer(null, null, null, ADMIN.id)).save();
+        const foundLayer = await Layer.findById(savedLayer._id);
         await new Layer(createLayer(null, null, null, USER.id)).save();
 
         createMockUserRole('ADMIN', ADMIN.id);
@@ -52,11 +54,12 @@ describe('Get layers', () => {
         });
 
         list.body.should.have.property('data').and.be.an('array').and.length(1);
-        ensureCorrectLayer(list.body.data[0], savedLayer.toObject());
+        ensureCorrectLayer(list.body.data[0], foundLayer.toObject());
     });
 
     it('Getting layers as ADMIN with query params user.role = MANAGER should return a list of layers created by MANAGER users (happy case)', async () => {
         const savedLayer = await new Layer(createLayer(null, null, null, MANAGER.id)).save();
+        const foundLayer = await Layer.findById(savedLayer._id);
         await new Layer(createLayer(null, null, null, USER.id)).save();
 
         createMockUserRole('MANAGER', MANAGER.id);
@@ -67,11 +70,12 @@ describe('Get layers', () => {
         });
 
         list.body.should.have.property('data').and.be.an('array').and.length(1);
-        ensureCorrectLayer(list.body.data[0], savedLayer.toObject());
+        ensureCorrectLayer(list.body.data[0], foundLayer.toObject());
     });
 
     it('Getting layers as ADMIN with query params user.role = USER should return a list of layers created by USER (happy case)', async () => {
         const savedLayer = await new Layer(createLayer(null, null, null, USER.id)).save();
+        const foundLayer = await Layer.findById(savedLayer._id);
         await new Layer(createLayer(null, null, null, MANAGER.id)).save();
 
         createMockUserRole('USER', USER.id);
@@ -82,11 +86,12 @@ describe('Get layers', () => {
         });
 
         list.body.should.have.property('data').and.be.an('array').and.length(1);
-        ensureCorrectLayer(list.body.data[0], savedLayer.toObject());
+        ensureCorrectLayer(list.body.data[0], foundLayer.toObject());
     });
 
     it('Getting layers as USER with query params user.role = USER and should return an unfiltered list of layers (happy case)', async () => {
         const savedLayer = await new Layer(createLayer(null, null, null, USER.id)).save();
+        const foundLayer = await Layer.findById(savedLayer._id);
         await new Layer(createLayer(null, null, null, MANAGER.id)).save();
 
         const list = await requester.get('/api/v1/layer').query({
@@ -95,11 +100,12 @@ describe('Get layers', () => {
         });
 
         list.body.should.have.property('data').and.be.an('array').and.length(2);
-        ensureCorrectLayer(list.body.data[0], savedLayer.toObject());
+        ensureCorrectLayer(list.body.data[0], foundLayer.toObject());
     });
 
     it('Getting layers as MANAGER with query params user.role = USER and should return an unfiltered list of layers (happy case)', async () => {
         const savedLayer = await new Layer(createLayer(null, null, null, USER.id)).save();
+        const foundLayer = await Layer.findById(savedLayer._id);
         await new Layer(createLayer(null, null, null, MANAGER.id)).save();
 
         const list = await requester.get('/api/v1/layer').query({
@@ -108,11 +114,12 @@ describe('Get layers', () => {
         });
 
         list.body.should.have.property('data').and.be.an('array').and.length(2);
-        ensureCorrectLayer(list.body.data[0], savedLayer.toObject());
+        ensureCorrectLayer(list.body.data[0], foundLayer.toObject());
     });
 
     it('Getting layers as anonymous user with includes=user should return a list of layers and no user data (happy case)', async () => {
         const savedLayer = await new Layer(createLayer(null, null, null, USER.id)).save();
+        const foundLayer = await Layer.findById(savedLayer._id);
 
         createMockUser([USER]);
 
@@ -123,7 +130,7 @@ describe('Get layers', () => {
 
         list.body.should.have.property('data').and.be.an('array').and.length.above(0);
 
-        ensureCorrectLayer(list.body.data[0], savedLayer.toObject(), {
+        ensureCorrectLayer(list.body.data[0], foundLayer.toObject(), {
             user: {
                 email: USER.email,
                 name: USER.name
@@ -133,6 +140,7 @@ describe('Get layers', () => {
 
     it('Getting layers with USER role and includes=user should return a list of layers and user name and email (happy case)', async () => {
         const savedLayer = await new Layer(createLayer(null, null, null, USER.id)).save();
+        const foundLayer = await Layer.findById(savedLayer._id);
 
         createMockUser([USER]);
 
@@ -143,7 +151,7 @@ describe('Get layers', () => {
             });
 
         list.body.should.have.property('data').and.be.an('array').and.length.above(0);
-        ensureCorrectLayer(list.body.data[0], savedLayer.toObject(), {
+        ensureCorrectLayer(list.body.data[0], foundLayer.toObject(), {
             user: {
                 email: USER.email,
                 name: USER.name
@@ -153,6 +161,7 @@ describe('Get layers', () => {
 
     it('Getting layers with MANAGER role and includes=user should return a list of layers and user name and email (happy case)', async () => {
         const savedLayer = await new Layer(createLayer(null, null, null, USER.id)).save();
+        const foundLayer = await Layer.findById(savedLayer._id);
 
         createMockUser([USER]);
 
@@ -163,7 +172,7 @@ describe('Get layers', () => {
             });
 
         list.body.should.have.property('data').and.be.an('array').and.length.above(0);
-        ensureCorrectLayer(list.body.data[0], savedLayer.toObject(), {
+        ensureCorrectLayer(list.body.data[0], foundLayer.toObject(), {
             user: {
                 email: USER.email,
                 name: USER.name
@@ -173,6 +182,7 @@ describe('Get layers', () => {
 
     it('Getting layers with ADMIN role and includes=user should return a list of layers and user name, email and role (happy case)', async () => {
         const savedLayer = await new Layer(createLayer(null, null, null, USER.id)).save();
+        const foundLayer = await Layer.findById(savedLayer._id);
 
         createMockUser([USER]);
 
@@ -183,7 +193,7 @@ describe('Get layers', () => {
             });
 
         list.body.should.have.property('data').and.be.an('array').and.length.above(0);
-        ensureCorrectLayer(list.body.data[0], savedLayer.toObject(), {
+        ensureCorrectLayer(list.body.data[0], foundLayer.toObject(), {
             user: {
                 email: USER.email,
                 name: USER.name,
@@ -196,9 +206,12 @@ describe('Get layers', () => {
         const savedLayerOne = await new Layer(createLayer()).save();
         const savedLayerTwo = await new Layer(createLayer()).save();
         const savedLayerThree = await new Layer(createLayer()).save();
+        const foundLayerOne = await Layer.findById(savedLayerOne._id);
+        const foundLayerTwo = await Layer.findById(savedLayerTwo._id);
+        const foundLayerThree = await Layer.findById(savedLayerThree._id);
 
         createMockUser([{
-            id: savedLayerOne.userId,
+            id: foundLayerOne.userId,
             role: 'USER',
             provider: 'local',
             email: 'user-one@control-tower.org',
@@ -216,7 +229,7 @@ describe('Get layers', () => {
         }]);
 
         createMockUser([{
-            id: savedLayerTwo.userId,
+            id: foundLayerTwo.userId,
             role: 'MANAGER',
             provider: 'local',
             email: 'user-two@control-tower.org',
@@ -228,7 +241,7 @@ describe('Get layers', () => {
         }]);
 
         createMockUser([{
-            id: savedLayerThree.userId,
+            id: foundLayerThree.userId,
             role: 'MANAGER',
             provider: 'local',
             name: 'user three',
@@ -246,20 +259,20 @@ describe('Get layers', () => {
             });
 
         list.body.should.have.property('data').and.be.an('array').and.length.above(0);
-        ensureCorrectLayer(list.body.data.find((layer) => layer.id === savedLayerOne.id), savedLayerOne.toObject(), {
+        ensureCorrectLayer(list.body.data.find((layer) => layer.id === foundLayerOne.id), foundLayerOne.toObject(), {
             user: {
                 email: 'user-one@control-tower.org',
                 name: 'test user',
                 role: 'USER'
             }
         });
-        ensureCorrectLayer(list.body.data.find((layer) => layer.id === savedLayerTwo.id), savedLayerTwo.toObject(), {
+        ensureCorrectLayer(list.body.data.find((layer) => layer.id === foundLayerTwo.id), foundLayerTwo.toObject(), {
             user: {
                 email: 'user-two@control-tower.org',
                 role: 'MANAGER'
             }
         });
-        ensureCorrectLayer(list.body.data.find((layer) => layer.id === savedLayerThree.id), savedLayerThree.toObject(), {
+        ensureCorrectLayer(list.body.data.find((layer) => layer.id === foundLayerThree.id), foundLayerThree.toObject(), {
             user: {
                 name: 'user three',
                 role: 'MANAGER'

--- a/app/test/e2e/layer-get.spec.js
+++ b/app/test/e2e/layer-get.spec.js
@@ -296,6 +296,12 @@ describe('Get layers', () => {
         list.body.links.should.have.property('last').and.not.includes('usersRole=');
     });
 
+    it('Getting layers with page size over 100 should return 400 Bad Request', async () => {
+        const list = await requester.get('/api/v1/layer?page[size]=101');
+        list.status.should.equal(400);
+        list.body.errors[0].should.have.property('detail').and.equal('Invalid page size');
+    });
+
     afterEach(async () => {
         await Layer.deleteMany({}).exec();
 

--- a/app/test/e2e/utils/mocks.js
+++ b/app/test/e2e/utils/mocks.js
@@ -12,18 +12,7 @@ const createMockUserRole = (role, userID) => nock(process.env.CT_URL)
     .get(`/auth/user/ids/${role}`)
     .reply(200, { data: [userID] });
 
-const mockUsersForSort = (users) => {
-    const betterUsers = users.map((u) => ({ ...u, _id: u.id }));
-
-    // Mock each user request (for includes=user)
-    betterUsers.map((user) => createMockUser([user]));
-
-    // Mock all users request (for sorting by user role)
-    createMockUser(betterUsers);
-};
-
 module.exports = {
     createMockUser,
-    createMockUserRole,
-    mockUsersForSort
+    createMockUserRole
 };

--- a/app/test/e2e/utils/mocks.js
+++ b/app/test/e2e/utils/mocks.js
@@ -1,12 +1,15 @@
 const nock = require('nock');
+const intersection = require('lodash/intersection');
 
-const createMockUser = (mockUser) => nock(process.env.CT_URL)
-    .post(`/auth/user/find-by-ids`, {
-        ids: mockUser.map((e) => e.id)
-    })
-    .reply(200, {
-        data: mockUser
-    });
+const createMockUser = (users) => {
+    nock(process.env.CT_URL)
+        .post(
+            '/auth/user/find-by-ids',
+            (body) => intersection(body.ids, users.map((e) => e._id.toString())).length === body.ids.length
+        )
+        .query(() => true)
+        .reply(200, { data: users });
+};
 
 const createMockUserRole = (role, userID) => nock(process.env.CT_URL)
     .get(`/auth/user/ids/${role}`)

--- a/app/test/e2e/utils/mocks.js
+++ b/app/test/e2e/utils/mocks.js
@@ -12,7 +12,18 @@ const createMockUserRole = (role, userID) => nock(process.env.CT_URL)
     .get(`/auth/user/ids/${role}`)
     .reply(200, { data: [userID] });
 
+const mockUsersForSort = (users) => {
+    const betterUsers = users.map((u) => ({ ...u, _id: u.id }));
+
+    // Mock each user request (for includes=user)
+    betterUsers.map((user) => createMockUser([user]));
+
+    // Mock all users request (for sorting by user role)
+    createMockUser(betterUsers);
+};
+
 module.exports = {
     createMockUser,
-    createMockUserRole
+    createMockUserRole,
+    mockUsersForSort
 };

--- a/app/test/e2e/utils/mocks.js
+++ b/app/test/e2e/utils/mocks.js
@@ -5,9 +5,8 @@ const createMockUser = (users) => {
     nock(process.env.CT_URL)
         .post(
             '/auth/user/find-by-ids',
-            (body) => intersection(body.ids, users.map((e) => e._id.toString())).length === body.ids.length
+            (body) => intersection(body.ids, users.map((e) => e.id.toString())).length === body.ids.length
         )
-        .query(() => true)
         .reply(200, { data: users });
 };
 

--- a/app/test/e2e/utils/test.constants.js
+++ b/app/test/e2e/utils/test.constants.js
@@ -1,5 +1,6 @@
 const USERS = {
     USER: {
+        _id: '1a10d7c6e0a37126611fd7a7',
         id: '1a10d7c6e0a37126611fd7a7',
         role: 'USER',
         provider: 'local',
@@ -18,6 +19,7 @@ const USERS = {
         }
     },
     MANAGER: {
+        _id: '1a10d7c6e0a37126611fd7a5',
         id: '1a10d7c6e0a37126611fd7a5',
         role: 'MANAGER',
         provider: 'local',
@@ -36,6 +38,7 @@ const USERS = {
         }
     },
     ADMIN: {
+        _id: '1a10d7c6e0a37126611fd7a6',
         id: '1a10d7c6e0a37126611fd7a6',
         role: 'ADMIN',
         provider: 'local',
@@ -54,6 +57,7 @@ const USERS = {
         }
     },
     SUPERADMIN: {
+        _id: '1a10d7c6e0a37126601fd7a6',
         id: '1a10d7c6e0a37126601fd7a6',
         role: 'SUPERADMIN',
         provider: 'local',

--- a/app/test/e2e/utils/test.constants.js
+++ b/app/test/e2e/utils/test.constants.js
@@ -1,6 +1,5 @@
 const USERS = {
     USER: {
-        _id: '1a10d7c6e0a37126611fd7a7',
         id: '1a10d7c6e0a37126611fd7a7',
         role: 'USER',
         provider: 'local',
@@ -19,7 +18,6 @@ const USERS = {
         }
     },
     MANAGER: {
-        _id: '1a10d7c6e0a37126611fd7a5',
         id: '1a10d7c6e0a37126611fd7a5',
         role: 'MANAGER',
         provider: 'local',
@@ -38,7 +36,6 @@ const USERS = {
         }
     },
     ADMIN: {
-        _id: '1a10d7c6e0a37126611fd7a6',
         id: '1a10d7c6e0a37126611fd7a6',
         role: 'ADMIN',
         provider: 'local',
@@ -57,7 +54,6 @@ const USERS = {
         }
     },
     SUPERADMIN: {
-        _id: '1a10d7c6e0a37126601fd7a6',
         id: '1a10d7c6e0a37126601fd7a6',
         role: 'SUPERADMIN',
         provider: 'local',

--- a/app/test/e2e/utils/test.constants.js
+++ b/app/test/e2e/utils/test.constants.js
@@ -54,11 +54,11 @@ const USERS = {
         }
     },
     SUPERADMIN: {
-        id: '1a10d7c6e0a37126611fd7a6',
+        id: '1a10d7c6e0a37126601fd7a6',
         role: 'SUPERADMIN',
         provider: 'local',
         email: 'user@control-tower.org',
-        name: 'test admin',
+        name: 'test super admin',
         extraUserData: {
             apps: [
                 'rw',

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "koa-router": "^7.4.0",
     "koa-simple-healthcheck": "^0.0.1",
     "koa-validate": "^1.0.7",
+    "lodash": "^4.17.15",
     "mongoose": "^5.7.11",
     "mongoose-paginate": "^5.0.3",
     "sd-ct-register-microservice-node": "^2.1.7",


### PR DESCRIPTION
This PR relates to the following PT task:

* https://www.pivotaltracker.com/story/show/169174283

## What does this PR add?

This PR adds the possibility of sorting layers according to the role or name of the user to whom the layer belongs.

It should be noted that, in order to accomplish this, **all layers are updated with the current role and name of the user associated before sorting the collection**. This has an impact on the performance of the GET endpoint, but this impact is reduced when taking into account that this sort will be used in conjunction with `includes=user` option.

For reference, a benchmark was performed on the impact of this feature, including ~5k layers created by ~40 different users. The results were the following:

* GET /layer => **~42.855ms**
* GET /layer?includes=user => **~172.069ms**
* GET /layer?includes=user&sort=user.role => **~346.044ms**