### PR TITLE
Send layers without user associated to the bottom when sorting by user fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 24/01/2020
+
+- Add possibility of sorting layers by user fields (such as name or role).
+
 # v1.0.0
 
 ## 14/01/2020

--- a/app/src/routes/api/v1/layer.router.js
+++ b/app/src/routes/api/v1/layer.router.js
@@ -162,10 +162,17 @@ class LayerRouter {
             await Promise.all(users.map((u) => LayerModel.updateMany(
                 { userId: u._id },
                 {
-                    userRole: u.role ? u.role.toLowerCase() : '',
-                    userName: u.name ? u.name.toLowerCase() : ''
+                    userRole: u.role ? u.role.toLowerCase() : '',
+                    userName: u.name ? u.name.toLowerCase() : ''
                 },
             )));
+
+            // Update layers with no user / invalid user associated so that
+            // they are sorted to the end of the list
+            await LayerModel.updateMany(
+                { userId: { $nin: ids } },
+                { userRole: '', userName: '' },
+            );
         }
 
         /**

--- a/app/test/e2e/layer-get-sort-user-fields.spec.js
+++ b/app/test/e2e/layer-get-sort-user-fields.spec.js
@@ -36,10 +36,7 @@ const mockLayersForSorting = async () => {
     await new Layer(createLayer(null, null, null, ADMIN.id)).save();
     await new Layer(createLayer(null, null, null, SUPERADMIN.id)).save();
     await new Layer(createLayer(null, null, null, id)).save();
-
-    mockUsersForSort([
-        USER, MANAGER, ADMIN, SUPERADMIN, { id }
-    ]);
+    mockUsersForSort([USER, MANAGER, ADMIN, SUPERADMIN, { id }]);
 };
 
 describe('GET layers sorted by user fields', () => {
@@ -81,7 +78,7 @@ describe('GET layers sorted by user fields', () => {
         });
         response.status.should.equal(200);
         response.body.should.have.property('data').and.be.an('array').and.length(5);
-        response.body.data.map((layer) => layer.attributes.user.role).should.be.deep.equal([undefined, 'ADMIN', 'MANAGER', 'SUPERADMIN', 'USER']);
+        response.body.data.map((layer) => layer.attributes.user.role).should.be.deep.equal(['ADMIN', 'MANAGER', 'SUPERADMIN', 'USER', undefined]);
     });
 
     it('Getting layers sorted by user.role DESC should return a list of layers ordered by the role of the user who created the layer (happy case)', async () => {
@@ -93,7 +90,7 @@ describe('GET layers sorted by user fields', () => {
         });
         response.status.should.equal(200);
         response.body.should.have.property('data').and.be.an('array').and.length(5);
-        response.body.data.map((layer) => layer.attributes.user.role).should.be.deep.equal(['USER', 'SUPERADMIN', 'MANAGER', 'ADMIN', undefined]);
+        response.body.data.map((layer) => layer.attributes.user.role).should.be.deep.equal([undefined, 'USER', 'SUPERADMIN', 'MANAGER', 'ADMIN']);
     });
 
     it('Getting layers sorted by user.name ASC should return a list of layers ordered by the name of the user who created the layer (happy case)', async () => {
@@ -105,7 +102,7 @@ describe('GET layers sorted by user fields', () => {
         });
         response.status.should.equal(200);
         response.body.should.have.property('data').and.be.an('array').and.length(5);
-        response.body.data.map((layer) => layer.attributes.user.name).should.be.deep.equal([undefined, 'test admin', 'test manager', 'test super admin', 'test user']);
+        response.body.data.map((layer) => layer.attributes.user.name).should.be.deep.equal(['test admin', 'test manager', 'test super admin', 'test user', undefined]);
     });
 
     it('Getting layers sorted by user.name DESC should return a list of layers ordered by the name of the user who created the layer (happy case)', async () => {
@@ -117,19 +114,17 @@ describe('GET layers sorted by user fields', () => {
         });
         response.status.should.equal(200);
         response.body.should.have.property('data').and.be.an('array').and.length(5);
-        response.body.data.map((layer) => layer.attributes.user.name).should.be.deep.equal(['test user', 'test super admin', 'test manager', 'test admin', undefined]);
+        response.body.data.map((layer) => layer.attributes.user.name).should.be.deep.equal([undefined, 'test user', 'test super admin', 'test manager', 'test admin']);
     });
 
-    it('Sorting layers by user role ASC puts layers without valid users in the beginning of the list', async () => {
+    it('Sorting layers by user role ASC puts layers without valid users in the end of the list', async () => {
         await new Layer(createLayer(null, null, null, USER.id)).save();
         await new Layer(createLayer(null, null, null, MANAGER.id)).save();
         await new Layer(createLayer(null, null, null, ADMIN.id)).save();
         await new Layer(createLayer(null, null, null, SUPERADMIN.id)).save();
         const noUserLayer = await new Layer(createLayer(null, null, null, 'legacy')).save();
 
-        mockUsersForSort([
-            USER, MANAGER, ADMIN, SUPERADMIN
-        ]);
+        mockUsersForSort([USER, MANAGER, ADMIN, SUPERADMIN]);
 
         const response = await requester.get('/api/v1/layer').query({
             includes: 'user',
@@ -140,19 +135,17 @@ describe('GET layers sorted by user fields', () => {
         response.body.should.have.property('data').and.be.an('array').and.length(5);
 
         const returnedNoUserLayer = response.body.data.find((layer) => layer.id === noUserLayer._id);
-        response.body.data.indexOf(returnedNoUserLayer).should.be.equal(0);
+        response.body.data.indexOf(returnedNoUserLayer).should.be.equal(4);
     });
 
-    it('Sorting layers by user role DESC puts layers without valid users in the end of the list', async () => {
+    it('Sorting layers by user role DESC puts layers without valid users in the beginning of the list', async () => {
         await new Layer(createLayer(null, null, null, USER.id)).save();
         await new Layer(createLayer(null, null, null, MANAGER.id)).save();
         await new Layer(createLayer(null, null, null, ADMIN.id)).save();
         await new Layer(createLayer(null, null, null, SUPERADMIN.id)).save();
         const noUserLayer = await new Layer(createLayer(null, null, null, 'legacy')).save();
 
-        mockUsersForSort([
-            USER, MANAGER, ADMIN, SUPERADMIN
-        ]);
+        mockUsersForSort([USER, MANAGER, ADMIN, SUPERADMIN]);
 
         const response = await requester.get('/api/v1/layer').query({
             includes: 'user',
@@ -163,7 +156,7 @@ describe('GET layers sorted by user fields', () => {
         response.body.should.have.property('data').and.be.an('array').and.length(5);
 
         const returnedNoUserLayer = response.body.data.find((layer) => layer.id === noUserLayer._id);
-        response.body.data.indexOf(returnedNoUserLayer).should.be.equal(4);
+        response.body.data.indexOf(returnedNoUserLayer).should.be.equal(0);
     });
 
     it('Sorting layers by user.name is case insensitive and returns a list of layers ordered by the name of the user who created the layer', async () => {


### PR DESCRIPTION
This PR relates to the following PT task:

* https://www.pivotaltracker.com/story/show/169174283

## What does this PR add?

This PR adds a behaviour of sending layers without user associated to the bottom of the list when sorting by user fields. The tests for this feature were also updated.

Inspiration drawn from here: https://stackoverflow.com/questions/8086375/what-character-to-use-to-put-an-item-at-the-end-of-an-alphabetic-list